### PR TITLE
Split Metadata from CType

### DIFF
--- a/src/ctypes/ctypes.controller.ts
+++ b/src/ctypes/ctypes.controller.ts
@@ -49,7 +49,7 @@ export class CTypesController {
       if (verified) {
         console.log(
           `All valid => registering cType ` +
-            cTypeInput.cType.metadata.title.default
+            JSON.stringify(cTypeInput.cType,null,4)
         )
         this.cTypesService.register(cTypeInput)
       } else {

--- a/src/ctypes/in-memory-ctypes.service.spec.ts
+++ b/src/ctypes/in-memory-ctypes.service.spec.ts
@@ -1,14 +1,14 @@
 import { InMemoryCTypesService } from './in-memory-ctypes.service'
 import { CType } from './interfaces/ctype.interfaces'
 import Optional from 'typescript-optional'
-import { IMetadata } from '@kiltprotocol/sdk-js/build/types/CTypeMetedata'
+import { ICTypeMetadata } from '@kiltprotocol/sdk-js'
 
 describe('InMemoryCTypesService', () => {
   const cTypesInMemoryService: InMemoryCTypesService = new InMemoryCTypesService()
 
   describe('root', () => {
     it('should create and find cType(s)', async () => {
-      const meta: IMetadata = {
+      const meta: ICTypeMetadata['metadata'] = {
         title: {
           default: 'myCTYPE',
         },
@@ -16,7 +16,7 @@ describe('InMemoryCTypesService', () => {
           default: 'myCTYPE description',
         },
         properties: {},
-      }as IMetadata
+      }
       const cType: CType = {
         cType: {
           hash: '999',

--- a/src/ctypes/in-memory-ctypes.service.spec.ts
+++ b/src/ctypes/in-memory-ctypes.service.spec.ts
@@ -1,30 +1,38 @@
 import { InMemoryCTypesService } from './in-memory-ctypes.service'
 import { CType } from './interfaces/ctype.interfaces'
 import Optional from 'typescript-optional'
+import { IMetadata } from '@kiltprotocol/sdk-js/build/types/CTypeMetedata'
 
 describe('InMemoryCTypesService', () => {
   const cTypesInMemoryService: InMemoryCTypesService = new InMemoryCTypesService()
 
   describe('root', () => {
     it('should create and find cType(s)', async () => {
-      const cType = {
+      const meta: IMetadata = {
+        title: {
+          default: 'myCTYPE',
+        },
+        description: {
+          default: 'myCTYPE description',
+        },
+        properties: {},
+      }as IMetadata
+      const cType: CType = {
         cType: {
           hash: '999',
-          schema: {},
-          metadata: {
-            title: {
-              default: 'myCTYPE',
-            },
-            description: {
-              default: 'myCTYPE description',
-            },
+          schema: {
+            $id: '',
+            $schema: '',
             properties: {},
-          },
-        },
-        metaData: {
-          author: 'apasch',
-        },
-      } as CType
+            type: 'object'},
+          owner: 'apasch',
+      },
+      metaData:{
+        metadata: meta,
+        ctypeHash: '999'
+      }
+    }
+
       await cTypesInMemoryService.register(cType)
       const result: Optional<CType> = await cTypesInMemoryService.findByHash(
         '999'
@@ -32,11 +40,12 @@ describe('InMemoryCTypesService', () => {
       expect(result.isPresent).toBe(true)
       result.ifPresent((foundCType: CType) => {
         expect(foundCType.cType.hash).toBe('999')
-        expect(foundCType.cType.metadata.title.default).toBe('myCTYPE')
-        expect(foundCType.metaData.author).toBe('apasch')
+        expect(foundCType.metaData.metadata.title.default).toBe('myCTYPE')
+        expect(foundCType.cType.owner).toBe('apasch')
       })
 
       const results: CType[] = await cTypesInMemoryService.findAll()
+      console.log(JSON.stringify(results,null,4))
       expect(results[0]).toBe(result.get())
       expect(results.length).toBe(1)
     })

--- a/src/ctypes/interfaces/ctype.interfaces.ts
+++ b/src/ctypes/interfaces/ctype.interfaces.ts
@@ -1,18 +1,14 @@
-import { ICType } from '@kiltprotocol/sdk-js'
+import { ICType, ICTypeMetadata } from '@kiltprotocol/sdk-js'
 import { Document } from 'mongoose'
 import Optional from 'typescript-optional'
 
 export interface CType {
-  metaData: {
-    author: string
-  }
+  metaData: ICTypeMetadata
   cType: ICType
 }
 
 export interface CTypeDB extends Document {
-  metaData: {
-    author: string
-  }
+  metaData: string
   cType: string
   hash: string
 }

--- a/src/ctypes/mongodb-ctypes.service.ts
+++ b/src/ctypes/mongodb-ctypes.service.ts
@@ -17,9 +17,8 @@ export class MongoDbCTypesService implements CTypeService {
     if (value.isPresent) {
       throw new AlreadyRegisteredException()
     }
-
     const createdCType = new this.cTypeDBModel({
-      metaData: cType.metaData,
+      metaData: JSON.stringify(cType.metaData),
       cType: JSON.stringify(cType.cType),
       hash: cType.cType.hash,
     } as CTypeDB)
@@ -49,7 +48,7 @@ export class MongoDbCTypesService implements CTypeService {
 function convertToCType(cTypeDB: CTypeDB): CType {
   const { metaData, cType } = cTypeDB
   return {
-    metaData,
+    metaData: JSON.parse(metaData),
     cType: JSON.parse(cType),
   }
 }

--- a/src/ctypes/schemas/ctypes.schema.ts
+++ b/src/ctypes/schemas/ctypes.schema.ts
@@ -1,9 +1,7 @@
 import * as mongoose from 'mongoose'
 
 export const CTypeSchema = new mongoose.Schema({
-  metaData: {
-    author: String,
-  },
+  metaData: mongoose.Schema.Types.Mixed,
   cType: mongoose.Schema.Types.Mixed,
   hash: String,
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,7 +41,7 @@
     lodash.camelcase "^4.3.0"
     protobufjs "^6.8.6"
 
-"@kiltprotocol/sdk-js@0.17.0":
+"@kiltprotocol/sdk-js@^0.x":
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.17.0.tgz#9af16539859219c988aaa69e3642d7cdb94537fe"
   integrity sha512-O+imN6Z2h854iD891EaJO276oVDWVvZzrC+keOB1YByZYplyyk7etVv+Ekr2PAsWGAtVCKI6as2QX4m0BLLwFQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,10 +41,10 @@
     lodash.camelcase "^4.3.0"
     protobufjs "^6.8.6"
 
-"@kiltprotocol/sdk-js@^0.x":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.16.1.tgz#a535783134829ff633b9aaab50edccf8677295ba"
-  integrity sha512-+ssIgXfLoVff1HsQQgGy518k5drHqY2dacJ/c6HFtrtU3jC8Xba5DTNAY/qzTr5N5YbDmxT7sEHnzcigtMPr4g==
+"@kiltprotocol/sdk-js@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/sdk-js/-/sdk-js-0.17.0.tgz#9af16539859219c988aaa69e3642d7cdb94537fe"
+  integrity sha512-O+imN6Z2h854iD891EaJO276oVDWVvZzrC+keOB1YByZYplyyk7etVv+Ekr2PAsWGAtVCKI6as2QX4m0BLLwFQ==
   dependencies:
     "@polkadot/api" "^0.96.1"
     "@polkadot/keyring" "^1.7.0-beta.5"
@@ -55,7 +55,6 @@
     ajv "^6.6.1"
     bn.js "^4.11.8"
     jsonabc "^2.3.1"
-    lodash "^4.17.11"
     typescript-logging "^0.6.3"
     uuid "^3.3.2"
 


### PR DESCRIPTION
## fixes compatibility with https://github.com/KILTprotocol/ticket/issues/15
Updated definitions to accept incoming cTypes with split up metadata.

Storage went from 

```
metaData: {
  author: string
}
cType: { hash: string, owner: string, schema: ICTypeSchema, metadata: IMetadata }
```

to:

```
metaData: { metadata: IMetadata, ctypeHash: string}
cType: { hash: string, owner: string, schema: ICTypeSchema }
```

## How to test:
setup kilt dev environment, create ctypes with demo-client, should be registered on services.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
