### PR TITLE
ci: use github actions instead of aws CI

### DIFF
--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -28,7 +28,6 @@ on:
   push:
     branches:
       - develop
-      - tw-use-github-actions
 
 name: Deploy to Amazon ECS
 

--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -1,0 +1,83 @@
+# This workflow will build and push a new container image to Amazon ECR,
+# and then will deploy a new task definition to Amazon ECS, on every push
+# to the master branch.
+#
+# To use this workflow, you will need to complete the following set-up steps:
+#
+# 1. Create an ECR repository to store your images.
+#    For example: `aws ecr create-repository --repository-name my-ecr-repo --region us-east-2`.
+#    Replace the value of `ECR_REPOSITORY` in the workflow below with your repository's name.
+#    Replace the value of `aws-region` in the workflow below with your repository's region.
+#
+# 2. Create an ECS task definition, an ECS cluster, and an ECS service.
+#    For example, follow the Getting Started guide on the ECS console:
+#      https://us-east-2.console.aws.amazon.com/ecs/home?region=us-east-2#/firstRun
+#    Replace the values for `service` and `cluster` in the workflow below with your service and cluster names.
+#
+# 3. Store your ECS task definition as a JSON file in your repository.
+#    The format should follow the output of `aws ecs register-task-definition --generate-cli-skeleton`.
+#    Replace the value of `task-definition` in the workflow below with your JSON file's name.
+#    Replace the value of `container-name` in the workflow below with the name of the container
+#    in the `containerDefinitions` section of the task definition.
+#
+# 4. Store an IAM user access key in GitHub Actions secrets named `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+#    See the documentation for each action used below for the recommended IAM policies for this IAM user,
+#    and best practices on handling the access key credentials.
+
+on:
+  push:
+    branches:
+      - develop
+      - tw-use-github-actions
+
+name: Deploy to Amazon ECS
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-central-1
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: kilt/prototype-services
+        IMAGE_TAG: latest-develop
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+    - name: Fill in the new image ID in the Amazon ECS task definition
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition.json
+        container-name: demo-services
+        image: ${{ steps.build-image.outputs.image }}
+
+    - name: Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: demo-services
+        cluster: kilt-devnet
+        wait-for-service-stability: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: Lint and Test
+
+on:
+  push:
+    branches: 
+      - develop
+      - master
+    tags:
+      - '*'
+  pull_request:
+    branches: 
+      - develop
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: yarn install, lint and test
+      run: |
+        yarn install --frozen-lockfile
+        yarn lint
+        yarn test
+      env:
+        CI: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,9 @@ FROM node:10-alpine
 
 WORKDIR /app
 
-RUN apk add yarn
-
 COPY . ./
 
-# environment variable $KILT_NPM_AUTH_TOKEN must be provided when building the image:
-# docker built --build-arg KILT_NPM_AUTH_TOKEN=xxx ...
-ARG KILT_NPM_AUTH_TOKEN=""
-RUN echo "//registry.npmjs.org/:_authToken=$KILT_NPM_AUTH_TOKEN" > .npmrc
-RUN yarn config set @kiltprotocol:registry https://registry.npmjs.org
-
 RUN yarn install
-RUN yarn upgrade "@kiltprotocol/prototype-sdk"
 RUN yarn build
 
 EXPOSE 3000

--- a/src/ctypes/ctypes.controller.ts
+++ b/src/ctypes/ctypes.controller.ts
@@ -49,7 +49,7 @@ export class CTypesController {
       if (verified) {
         console.log(
           `All valid => registering cType ` +
-            JSON.stringify(cTypeInput.cType,null,4)
+            JSON.stringify(cTypeInput.cType, null, 4)
         )
         this.cTypesService.register(cTypeInput)
       } else {

--- a/src/ctypes/in-memory-ctypes.service.spec.ts
+++ b/src/ctypes/in-memory-ctypes.service.spec.ts
@@ -24,14 +24,15 @@ describe('InMemoryCTypesService', () => {
             $id: '',
             $schema: '',
             properties: {},
-            type: 'object'},
+            type: 'object',
+          },
           owner: 'apasch',
-      },
-      metaData:{
-        metadata: meta,
-        ctypeHash: '999'
+        },
+        metaData: {
+          metadata: meta,
+          ctypeHash: '999',
+        },
       }
-    }
 
       await cTypesInMemoryService.register(cType)
       const result: Optional<CType> = await cTypesInMemoryService.findByHash(
@@ -45,7 +46,7 @@ describe('InMemoryCTypesService', () => {
       })
 
       const results: CType[] = await cTypesInMemoryService.findAll()
-      console.log(JSON.stringify(results,null,4))
+      console.log(JSON.stringify(results, null, 4))
       expect(results[0]).toBe(result.get())
       expect(results.length).toBe(1)
     })

--- a/task-definition.json
+++ b/task-definition.json
@@ -1,0 +1,65 @@
+{
+  "family": "devnet-demo-services",
+  "taskRoleArn": "arn:aws:iam::348099934012:role/ecsTaskExecutionRole",
+  "executionRoleArn": "arn:aws:iam::348099934012:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "name": "demo-services",
+      "image": "348099934012.dkr.ecr.eu-central-1.amazonaws.com/kilt/prototype-services:0.13.2",
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/kilt-prototype-services-taskdef",
+          "awslogs-region": "eu-central-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "portMappings": [
+        {
+          "containerPort": 3000,
+          "hostPort": 3000,
+          "protocol": "tcp"
+        }
+      ],
+      "secrets": [
+        {
+          "name": "FAUCET_ACCOUNT",
+          "valueFrom": "arn:aws:ssm:eu-central-1:348099934012:parameter/ECS/devnet/faucet_account"
+        },
+        {
+          "name": "MONGODB_USER",
+          "valueFrom": "arn:aws:ssm:eu-central-1:348099934012:parameter/ECS/devnet/mongodb_user"
+        },
+        {
+          "name": "MONGODB_PASS",
+          "valueFrom": "arn:aws:ssm:eu-central-1:348099934012:parameter/ECS/devnet/mongodb_pass"
+        },
+        {
+          "name": "SECRET",
+          "valueFrom": "arn:aws:ssm:eu-central-1:348099934012:parameter/ECS/devnet/services_secret"
+        }
+      ],
+      "environment": [
+        {
+          "name": "BOOT_NODE_ADDRESS",
+          "value": "wss://full-nodes-lb.devnet.kilt.io:9944"
+        },
+        {
+          "name": "NODE_ENV",
+          "value": "dev-aws"
+        },
+        {
+          "name": "MONGODB_HOST",
+          "value": "mongodb.devnet.kilt.io"
+        }
+      ],
+      "essential": true
+    }
+  ],
+  "cpu": "512",
+  "memory": "1024",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "networkMode": "awsvpc"
+}


### PR DESCRIPTION
## refs https://github.com/KILTprotocol/ticket/issues/213
This PR converts our AWS Codepipeline tasks to github actions

## How to test:
- Look at the successfully running tests
- See the automatically deployed devnet demo service in aws

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
