### PR TITLE
refactor: replaced TxStatus with SubmittableResult

### DIFF
--- a/src/faucet/faucet.controller.ts
+++ b/src/faucet/faucet.controller.ts
@@ -1,4 +1,4 @@
-import { Balance, Identity, TxStatus } from '@kiltprotocol/sdk-js'
+import { Balance, Identity, SubmittableResult } from '@kiltprotocol/sdk-js'
 import {
   Controller,
   Inject,
@@ -68,12 +68,12 @@ export class FaucetController {
       const faucetAccount: Identity = Identity.buildFromSeed(
         hexToU8a(process.env.FAUCET_ACCOUNT)
       )
-      const status: TxStatus = await Balance.makeTransfer(
+      const status: SubmittableResult = await Balance.makeTransfer(
         faucetAccount,
         address,
         new BN(DEFAULT_TOKEN_AMOUNT)
       )
-      return Promise.resolve(status.type === 'Finalized')
+      return Promise.resolve(status.isFinalized)
     } catch (e) {
       console.error(e)
       return Promise.resolve(false)


### PR DESCRIPTION
## part of KILTProtocol/ticket#392
Removing TxStatus from the SDK (see ticket) requires a small change here as well.

## How to test:
- checkout sdk on branch rf-drop-TxStatus & run yalc publish
- on prototype-services, link sdk with yalc add '@kiltprotocol/sdk-js'
- yarn install, then start services and demo client & test via bootstrap tools & manual steps

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
