### PR TITLE
ci: test against a development version of the sdk

### DIFF
--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -55,6 +55,16 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
+      - name: set up .npmrc & .yarnrc to connect to github packages
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10
+        registry-url: https://npm.pkg.github.com
+        scope: '@kiltprotocol'
+
+    - name: set sdk dependency to 'latest'
+      run: echo $(jq '.dependencies."@kiltprotocol/portablegabi"="latest"' package.json) > package.json
+
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:
@@ -63,7 +73,7 @@ jobs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG .
+        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG --build-arg NODE_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }} .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG"
 

--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -55,7 +55,7 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
 
-      - name: set up .npmrc & .yarnrc to connect to github packages
+    - name: set up .npmrc & .yarnrc to connect to github packages
       uses: actions/setup-node@v1
       with:
         node-version: 10

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,11 +27,14 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+        registry-url: https://npm.pkg.github.com
+        scope: '@kiltprotocol'
     - name: yarn install, lint, test and build
       run: |
-        yarn install --frozen-lockfile
+        yarn upgrade --scope @kiltprotocol --latest
         yarn lint
         yarn test
         yarn build
       env:
         CI: true
+        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM node:10-alpine
+ARG NODE_AUTH_TOKEN=""
 
 WORKDIR /app
 
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+COPY ?npmrc ?yarnrc ./
+RUN yarn install
 
 COPY . ./
 RUN yarn build


### PR DESCRIPTION
## fixes KILTProtocol/ticket#582
This uses a development version of the sdk and Portablegabi, published to [GitHub Packages](https://github.com/orgs/KILTprotocol/packages) to build devnet images and to run tests.

## How to test:
- [x] fix typescript version issues with polkadot on sdk and merge to develop to trigger push to the GH packages repo
- [x] re-run ci
- [ ] merge and hope the devnet image building actually works

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
