### PR TITLE
fix: destructuring of message before responding

### DIFF
--- a/src/ctypes/ctypes.controller.ts
+++ b/src/ctypes/ctypes.controller.ts
@@ -41,7 +41,7 @@ export class CTypesController {
   @Delete()
   public async removeAll() {
     console.log('Remove all CTypes')
-    this.cTypesService.removeAll()
+    await this.cTypesService.removeAll()
   }
 
   @Post()

--- a/src/ctypes/ctypes.controller.ts
+++ b/src/ctypes/ctypes.controller.ts
@@ -41,7 +41,7 @@ export class CTypesController {
   @Delete()
   public async removeAll() {
     console.log('Remove all CTypes')
-    await this.cTypesService.removeAll()
+    this.cTypesService.removeAll()
   }
 
   @Post()

--- a/src/messaging/mongodb-messaging.service.ts
+++ b/src/messaging/mongodb-messaging.service.ts
@@ -20,13 +20,43 @@ export class MongoDbMessagingService implements MessagingService {
   public async findBySenderAddress(
     senderAddress: IEncryptedMessage['senderAddress']
   ): Promise<IEncryptedMessage[]> {
-    return await this.messageModel.find({ senderAddress }).exec()
+    return (await this.messageModel.find({ senderAddress }).exec()).map(
+      (singleDBMessage: MessageDB) => {
+        return {
+          message: singleDBMessage.message,
+          nonce: singleDBMessage.nonce,
+          createdAt: singleDBMessage.createdAt,
+          hash: singleDBMessage.hash,
+          signature: singleDBMessage.signature,
+          receiverAddress: singleDBMessage.receiverAddress,
+          senderAddress: singleDBMessage.senderAddress,
+          senderBoxPublicKey: singleDBMessage.senderBoxPublicKey,
+          messageId: singleDBMessage.messageId,
+          receivedAt: singleDBMessage.receivedAt,
+        } as IEncryptedMessage
+      }
+    ) as IEncryptedMessage[]
   }
 
   public async findByReceiverAddress(
     receiverAddress: IEncryptedMessage['receiverAddress']
   ): Promise<IEncryptedMessage[]> {
-    return await this.messageModel.find({ receiverAddress }).exec()
+    return (await this.messageModel.find({ receiverAddress }).exec()).map(
+      (singleDBMessage: MessageDB) => {
+        return {
+          message: singleDBMessage.message,
+          nonce: singleDBMessage.nonce,
+          createdAt: singleDBMessage.createdAt,
+          hash: singleDBMessage.hash,
+          signature: singleDBMessage.signature,
+          receiverAddress: singleDBMessage.receiverAddress,
+          senderAddress: singleDBMessage.senderAddress,
+          senderBoxPublicKey: singleDBMessage.senderBoxPublicKey,
+          messageId: singleDBMessage.messageId,
+          receivedAt: singleDBMessage.receivedAt,
+        } as IEncryptedMessage
+      }
+    ) as IEncryptedMessage[]
   }
 
   public async remove(


### PR DESCRIPTION
## fixes KILTprotocol/ticket/issues/668

destructures the querried MessageDB to IEncryptedMessage.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
