### PR TITLE
Added auth guarded delete for faucet

### DIFF
--- a/src/faucet/faucet.controller.ts
+++ b/src/faucet/faucet.controller.ts
@@ -59,9 +59,9 @@ export class FaucetController {
 
   @UseGuards(AuthGuard)
   @Delete()
-  public async removeAll() {
+  public async reset() {
     console.log('Purging faucet drop registry')
-    this.faucetService.removeAll()
+    this.faucetService.reset()
   }
 
   private async transferTokens(address: string): Promise<boolean> {

--- a/src/faucet/faucet.controller.ts
+++ b/src/faucet/faucet.controller.ts
@@ -6,6 +6,8 @@ import {
   Req,
   Body,
   BadRequestException,
+  Delete,
+  UseGuards,
 } from '@nestjs/common'
 import { Request } from 'express'
 import BN from 'bn.js'
@@ -18,6 +20,7 @@ import {
   FaucetDropFailedTransferException,
   FaucetDropInvalidAddressException,
 } from './exceptions'
+import { AuthGuard } from '../auth/auth.guard'
 
 const KILT_FEMTO_COIN = '1000000000000000'
 const DEFAULT_TOKEN_AMOUNT = 500
@@ -52,6 +55,13 @@ export class FaucetController {
     } else {
       throw new FaucetDropThrottledException()
     }
+  }
+
+  @UseGuards(AuthGuard)
+  @Delete()
+  public async removeAll() {
+    console.log('Purging faucet drop registry')
+    this.faucetService.removeAll()
   }
 
   private async transferTokens(address: string): Promise<boolean> {

--- a/src/faucet/faucet.module.spec.ts
+++ b/src/faucet/faucet.module.spec.ts
@@ -17,6 +17,7 @@ import { Request } from 'express'
 import { BadRequestException } from '@nestjs/common'
 import { MongoDbFaucetService } from './mongodb-faucet.service'
 import { getModelToken } from '@nestjs/mongoose'
+import { AuthGuard } from '../auth/auth.guard'
 
 jest.mock('@kiltprotocol/sdk-js/build/balance/Balance.chain', () => {
   return {
@@ -83,7 +84,10 @@ describe('Faucet Module', () => {
             useValue: fakeFaucetService,
           },
         ],
-      }).compile()
+      })
+        .overrideGuard(AuthGuard)
+        .useValue({ canActivate: () => true })
+        .compile()
 
       faucetController = moduleRef.get(FaucetController)
       faucetService = moduleRef.get('FaucetService')
@@ -95,9 +99,9 @@ describe('Faucet Module', () => {
         const buildSpy = jest
           .spyOn(Identity, 'buildFromSeed')
           .mockResolvedValue(faucetIdentity)
-        expect(await faucetController.drop(claimerAddress, faucetRequest)).toEqual(
-          undefined
-        )
+        expect(
+          await faucetController.drop(claimerAddress, faucetRequest)
+        ).toEqual(undefined)
         expect(dropSpy).toHaveBeenCalledWith(
           claimerAddress,
           testFaucetDrop.requestip,
@@ -183,7 +187,9 @@ describe('Faucet Module', () => {
             isFinalized: true,
           } as SubmittableResult
         })
-        expect(await faucetController['transferTokens'](claimerAddress)).toEqual(true)
+        expect(
+          await faucetController['transferTokens'](claimerAddress)
+        ).toEqual(true)
         expect(buildSpy).toHaveBeenCalledWith(
           hexToU8a(process.env.FAUCET_ACCOUNT)
         )
@@ -200,7 +206,9 @@ describe('Faucet Module', () => {
             throw new Error('buildFromSeed failed')
           })
 
-        expect(await faucetController['transferTokens'](claimerAddress)).toEqual(false)
+        expect(
+          await faucetController['transferTokens'](claimerAddress)
+        ).toEqual(false)
         expect(buildSpy).toHaveBeenCalledWith(
           hexToU8a(process.env.FAUCET_ACCOUNT)
         )
@@ -209,7 +217,9 @@ describe('Faucet Module', () => {
         mockedMakeTransfer.mockImplementation(() => {
           throw new Error('makeTransfer failed')
         })
-        expect(await faucetController['transferTokens'](claimerAddress)).toEqual(false)
+        expect(
+          await faucetController['transferTokens'](claimerAddress)
+        ).toEqual(false)
         expect(buildSpy).toHaveBeenCalledWith(
           hexToU8a(process.env.FAUCET_ACCOUNT)
         )
@@ -223,7 +233,9 @@ describe('Faucet Module', () => {
             isFinalized: false,
           } as SubmittableResult
         })
-        expect(await faucetController['transferTokens'](claimerAddress)).toEqual(false)
+        expect(
+          await faucetController['transferTokens'](claimerAddress)
+        ).toEqual(false)
         expect(buildSpy).toHaveBeenCalledWith(
           hexToU8a(process.env.FAUCET_ACCOUNT)
         )

--- a/src/faucet/mongodb-faucet.service.ts
+++ b/src/faucet/mongodb-faucet.service.ts
@@ -71,9 +71,6 @@ export class MongoDbFaucetService implements FaucetService {
     await createdFaucetDrop.save()
     return createdFaucetDrop as FaucetDrop
   }
-  public async removeAll(): Promise<void> {
-    this.faucetDropDBModel.deleteMany({}).exec()
-  }
 
   public async updateOnTransactionFailure(drop: FaucetDrop): Promise<void> {
     drop.error = ERROR_TRANSACTION_FAILED

--- a/src/faucet/mongodb-faucet.service.ts
+++ b/src/faucet/mongodb-faucet.service.ts
@@ -71,6 +71,9 @@ export class MongoDbFaucetService implements FaucetService {
     await createdFaucetDrop.save()
     return createdFaucetDrop as FaucetDrop
   }
+  public async removeAll(): Promise<void> {
+    this.faucetDropDBModel.deleteMany({}).exec()
+  }
 
   public async updateOnTransactionFailure(drop: FaucetDrop): Promise<void> {
     drop.error = ERROR_TRANSACTION_FAILED


### PR DESCRIPTION
## fixes KILTProtocol/ticket#728

Added simple auth guarded removeAll function that calls deleteMany with inclusive parameter, to purge faucet drop registry.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
