### PR TITLE
chore: store did as signed DidDocument

### DIFF
--- a/src/contacts/interfaces/contacts.interfaces.ts
+++ b/src/contacts/interfaces/contacts.interfaces.ts
@@ -1,4 +1,5 @@
 import { PublicIdentity } from '@kiltprotocol/sdk-js'
+import { IDidDocumentSigned } from '@kiltprotocol/sdk-js/build/did/Did'
 import { Document } from 'mongoose'
 import Optional from 'typescript-optional'
 
@@ -6,8 +7,7 @@ export interface Contact {
   metaData: {
     name: string
   }
-  did?: object
-  signature?: string
+  did?: IDidDocumentSigned
   publicIdentity: PublicIdentity
 }
 

--- a/src/contacts/schemas/contacts.schema.ts
+++ b/src/contacts/schemas/contacts.schema.ts
@@ -5,7 +5,6 @@ export const ContactSchema = new mongoose.Schema({
     name: String,
   },
   did: Object,
-  signature: String,
   publicIdentity: {
     address: String,
     boxPublicKeyAsHex: String,


### PR DESCRIPTION
## fixes KILTProtocol/ticket#722 ## fixes KILTProtocol/ticket#687

Removes signature field from storage schema and Contact Interface, and expects stores and returns the did as `IDidDocumentSigned`. 

The demo-client has to be updated to post contacts with updated from.


## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
