### PR TITLE
Use the SDK based unit conversions and denomination

### DIFF
--- a/src/faucet/faucet.controller.ts
+++ b/src/faucet/faucet.controller.ts
@@ -73,7 +73,8 @@ export class FaucetController {
       const status: SubmittableResult = await Balance.makeTransfer(
         faucetAccount,
         address,
-        new BN(KILT_FEMTO_COIN).muln(DEFAULT_TOKEN_AMOUNT)
+        new BN(DEFAULT_TOKEN_AMOUNT),
+        0
       )
       return Promise.resolve(status.isFinalized)
     } catch (e) {

--- a/src/faucet/faucet.controller.ts
+++ b/src/faucet/faucet.controller.ts
@@ -22,7 +22,6 @@ import {
 } from './exceptions'
 import { AuthGuard } from '../auth/auth.guard'
 
-const KILT_FEMTO_COIN = '1000000000000000'
 const DEFAULT_TOKEN_AMOUNT = 500
 
 @Controller('faucet')

--- a/src/faucet/faucet.module.spec.ts
+++ b/src/faucet/faucet.module.spec.ts
@@ -110,7 +110,8 @@ describe('Faucet Module', () => {
         expect(mockedMakeTransfer).toHaveBeenCalledWith(
           faucetIdentity,
           claimerAddress,
-          new BN(KILT_FEMTO_COIN).muln(DEFAULT_TOKEN_AMOUNT)
+          new BN(DEFAULT_TOKEN_AMOUNT),
+          0
         )
       })
       it('updates the database on unsuccessful transfer and throws exception', async () => {
@@ -136,7 +137,8 @@ describe('Faucet Module', () => {
         expect(mockedMakeTransfer).toHaveBeenCalledWith(
           faucetIdentity,
           claimerAddress,
-          new BN(KILT_FEMTO_COIN).muln(DEFAULT_TOKEN_AMOUNT)
+          new BN(DEFAULT_TOKEN_AMOUNT),
+          0
         )
         expect(updateSpy).toHaveBeenCalledWith(testFaucetDrop)
       })
@@ -196,7 +198,8 @@ describe('Faucet Module', () => {
         expect(mockedMakeTransfer).toHaveBeenCalledWith(
           faucetIdentity,
           claimerAddress,
-          new BN(KILT_FEMTO_COIN).muln(DEFAULT_TOKEN_AMOUNT)
+          new BN(DEFAULT_TOKEN_AMOUNT),
+          0
         )
       })
       it(`returns false on thrown error or if the transfer failed`, async () => {
@@ -226,7 +229,8 @@ describe('Faucet Module', () => {
         expect(mockedMakeTransfer).toHaveBeenCalledWith(
           faucetIdentity,
           claimerAddress,
-          new BN(KILT_FEMTO_COIN).muln(DEFAULT_TOKEN_AMOUNT)
+          new BN(DEFAULT_TOKEN_AMOUNT),
+          0
         )
         mockedMakeTransfer.mockImplementation(async () => {
           return {
@@ -242,7 +246,8 @@ describe('Faucet Module', () => {
         expect(mockedMakeTransfer).toHaveBeenCalledWith(
           faucetIdentity,
           claimerAddress,
-          new BN(KILT_FEMTO_COIN).muln(DEFAULT_TOKEN_AMOUNT)
+          new BN(DEFAULT_TOKEN_AMOUNT),
+          0
         )
       })
     })

--- a/test/faucet.e2e-spec.ts
+++ b/test/faucet.e2e-spec.ts
@@ -69,7 +69,8 @@ describe('faucet endpoint (e2e)', () => {
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({ seedAsHex: FAUCET_SEED }),
       idAlice.address,
-      expect.any(BN)
+      expect.any(BN),
+      0
     )
   })
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#751

Uses updated SDK makeTransfer to transfer appropriate amounts of coins on faucet drop.


## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
