### PR TITLE
Update stored contacts with deprecated DID Format, respond with SDK Format for outdated Contacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@godaddy/terminus": "^4.1.0",
-    "@kiltprotocol/sdk-js": "^0.19.1-d0076cb.0",
+    "@kiltprotocol/sdk-js": "^0.19.1-affad9.0",
     "@nestjs/common": "^5.4.0",
     "@nestjs/core": "^5.4.0",
     "@nestjs/mongoose": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@godaddy/terminus": "^4.1.0",
-    "@kiltprotocol/sdk-js": "^0.19.1-affad9.0",
+    "@kiltprotocol/sdk-js": "^0.19.1-affad9d.0",
     "@nestjs/common": "^5.4.0",
     "@nestjs/core": "^5.4.0",
     "@nestjs/mongoose": "^5.2.2",

--- a/src/contacts/contacts.module.spec.ts
+++ b/src/contacts/contacts.module.spec.ts
@@ -354,13 +354,6 @@ describe('Contact Module', () => {
         findOneSpy.mockReturnValue({
           exec: async (): Promise<ContactDB> =>
             (({
-              ...testContact,
-              toObject: () => testContact,
-            } as any) as ContactDB),
-        })
-        findOneSpy.mockReturnValue({
-          exec: async (): Promise<ContactDB> =>
-            (({
               ...deprecatedDIDFormat,
               toObject: () => deprecatedDIDFormat,
             } as any) as ContactDB),

--- a/src/contacts/contacts.module.spec.ts
+++ b/src/contacts/contacts.module.spec.ts
@@ -90,7 +90,7 @@ describe('Contact Module', () => {
   const deprecatedDIDFormat: Contact = {
     ...testContact,
     signature,
-    did: {},
+    did: unsignedTestDID,
   } as any
   const address = testContact.publicIdentity.address
   describe('Controller', () => {
@@ -351,7 +351,24 @@ describe('Contact Module', () => {
         expect(findOneSpy).toHaveBeenCalledWith({
           'publicIdentity.address': address,
         })
-        expect(findOneSpy).toHaveBeenCalledTimes(2)
+        findOneSpy.mockReturnValue({
+          exec: async (): Promise<ContactDB> =>
+            (({
+              ...testContact,
+              toObject: () => testContact,
+            } as any) as ContactDB),
+        })
+        findOneSpy.mockReturnValue({
+          exec: async (): Promise<ContactDB> =>
+            (({
+              ...deprecatedDIDFormat,
+              toObject: () => deprecatedDIDFormat,
+            } as any) as ContactDB),
+        })
+        expect(await contactsService.findByAddress(address)).toEqual(
+          Optional.ofNullable<Contact>(contactWithDid)
+        )
+        expect(findOneSpy).toHaveBeenCalledTimes(3)
         findOneSpy.mockRestore()
       })
     })

--- a/src/contacts/mongodb-contacts.service.ts
+++ b/src/contacts/mongodb-contacts.service.ts
@@ -26,6 +26,7 @@ export class MongoDbMContactsService implements ContactsService {
     )
     if (registeredContact.isPresent) {
       const registered = registeredContact.get()
+      //If the contact was already registered we want to replace the document, as it could exist in outdated format!
       await this.contactModel.replaceOne({ _id: registered._id }, {
         did: registered.signature && { ...registered.did, signature: registered.signature },
         ...contact,

--- a/src/contacts/mongodb-contacts.service.ts
+++ b/src/contacts/mongodb-contacts.service.ts
@@ -28,7 +28,10 @@ export class MongoDbMContactsService implements ContactsService {
       const registered = registeredContact.get()
       //If the contact was already registered we want to replace the document, as it could exist in outdated format!
       await this.contactModel.replaceOne({ _id: registered._id }, {
-        did: registered.signature && { ...registered.did, signature: registered.signature },
+        did: registered.signature && {
+          ...registered.did,
+          signature: registered.signature,
+        },
         ...contact,
         publicIdentity: registered.publicIdentity,
         metaData: {

--- a/src/contacts/mongodb-contacts.service.ts
+++ b/src/contacts/mongodb-contacts.service.ts
@@ -33,6 +33,10 @@ export class MongoDbMContactsService implements ContactsService {
       await new this.contactModel({
         ...contact,
         publicIdentity: registeredContact.get().publicIdentity,
+        metaData: {
+          ...registeredContact.get().metaData,
+          name: contact.metaData.name,
+        },
       } as ContactDB).save()
     } else {
       await new this.contactModel(contact as ContactDB).save()

--- a/src/contacts/mongodb-contacts.service.ts
+++ b/src/contacts/mongodb-contacts.service.ts
@@ -17,22 +17,20 @@ export class MongoDbMContactsService implements ContactsService {
   ) {}
 
   public async add(contact: Contact): Promise<void> {
-    const modifiedContact: Optional<ContactDB> = Optional.ofNullable<ContactDB>(
+    const registeredContact: Optional<ContactDB> = Optional.ofNullable<
+      ContactDB
+    >(
       await this.contactModel
         .findOne({ 'publicIdentity.address': contact.publicIdentity.address })
         .exec()
     )
-    if (modifiedContact.isPresent) {
+    if (registeredContact.isPresent) {
       await this.contactModel
         .deleteOne({
           'publicIdentity.address': contact.publicIdentity.address,
         })
         .exec()
-      const updatedContact = modifiedContact.get().toObject()
-      updatedContact.did = contact.did
-      updatedContact.metaData.name = contact.metaData.name
-      delete updatedContact.signature
-      await new this.contactModel(updatedContact as ContactDB).save()
+      await new this.contactModel(contact as ContactDB).save()
     } else {
       await new this.contactModel(contact as ContactDB).save()
     }

--- a/src/contacts/mongodb-contacts.service.ts
+++ b/src/contacts/mongodb-contacts.service.ts
@@ -26,7 +26,7 @@ export class MongoDbMContactsService implements ContactsService {
     )
     if (registeredContact.isPresent) {
       const registered = registeredContact.get()
-      //If the contact was already registered we want to replace the document, as it could exist in outdated format!
+      // If the contact was already registered we want to replace the document, as it could exist in outdated format!
       await this.contactModel.replaceOne({ _id: registered._id }, {
         did: registered.signature && {
           ...registered.did,
@@ -70,7 +70,7 @@ export class MongoDbMContactsService implements ContactsService {
   private convertToContact(
     contactDB: ContactDB & { signature?: string }
   ): Contact {
-    //The Old Format had the signature as property in ContactDB, so we check if we have to move it.
+    // The Old Format had the signature as property in ContactDB, so we check if we have to move it.
     const { metaData, did, publicIdentity, signature } = contactDB
     return {
       metaData,

--- a/src/contacts/mongodb-contacts.service.ts
+++ b/src/contacts/mongodb-contacts.service.ts
@@ -26,7 +26,7 @@ export class MongoDbMContactsService implements ContactsService {
     )
     if (registeredContact.isPresent) {
       const registered = registeredContact.get()
-      // If the contact was already registered we want to replace the document, as it could exist in outdated format!
+      // If the contact was already registered we want to replace the document, as it could exist in outdated format! Signature is still valid.
       await this.contactModel.replaceOne({ _id: registered._id }, {
         did: registered.signature && {
           ...registered.did,
@@ -70,7 +70,7 @@ export class MongoDbMContactsService implements ContactsService {
   private convertToContact(
     contactDB: ContactDB & { signature?: string }
   ): Contact {
-    // The Old Format had the signature as property in ContactDB, so we check if we have to move it.
+    // The Old Format had the signature as property in ContactDB, so we check if we have to move it. Signature is still valid.
     const { metaData, did, publicIdentity, signature } = contactDB
     return {
       metaData,

--- a/src/contacts/mongodb-contacts.service.ts
+++ b/src/contacts/mongodb-contacts.service.ts
@@ -30,7 +30,10 @@ export class MongoDbMContactsService implements ContactsService {
           'publicIdentity.address': contact.publicIdentity.address,
         })
         .exec()
-      await new this.contactModel(contact as ContactDB).save()
+      await new this.contactModel({
+        ...contact,
+        publicIdentity: registeredContact.get().publicIdentity,
+      } as ContactDB).save()
     } else {
       await new this.contactModel(contact as ContactDB).save()
     }

--- a/src/faucet/faucet.controller.ts
+++ b/src/faucet/faucet.controller.ts
@@ -1,4 +1,4 @@
-import { Balance, Blockchain, Identity } from '@kiltprotocol/sdk-js'
+import { Balance, Identity } from '@kiltprotocol/sdk-js'
 import {
   Controller,
   Inject,
@@ -79,9 +79,11 @@ export class FaucetController {
         new BN(DEFAULT_TOKEN_AMOUNT),
         0
       )
-      const status = await Blockchain.submitTxWithReSign(tx, faucetAccount, {
+      const status = await submitSignedTx(tx, {
         resolveOn: IS_IN_BLOCK,
       })
+      console.log(`Status: ${status.isInBlock}`)
+
       return Promise.resolve(status.isInBlock)
     } catch (e) {
       console.error(e)

--- a/src/faucet/faucet.controller.ts
+++ b/src/faucet/faucet.controller.ts
@@ -21,7 +21,7 @@ import {
   FaucetDropInvalidAddressException,
 } from './exceptions'
 import { AuthGuard } from '../auth/auth.guard'
-import { IS_IN_BLOCK } from '@kiltprotocol/sdk-js/build/blockchain/Blockchain'
+import { IS_IN_BLOCK, submitSignedTx } from '@kiltprotocol/sdk-js/build/blockchain/Blockchain'
 
 const DEFAULT_TOKEN_AMOUNT = 500
 
@@ -76,7 +76,7 @@ export class FaucetController {
         new BN(DEFAULT_TOKEN_AMOUNT),
         0
       )
-      const status = await Blockchain.submitSignedTx(tx, {
+      const status = await submitSignedTx(tx, {
         resolveOn: IS_IN_BLOCK,
       })
       return Promise.resolve(status.isInBlock)

--- a/src/faucet/faucet.controller.ts
+++ b/src/faucet/faucet.controller.ts
@@ -21,7 +21,10 @@ import {
   FaucetDropInvalidAddressException,
 } from './exceptions'
 import { AuthGuard } from '../auth/auth.guard'
-import { IS_IN_BLOCK, submitSignedTx } from '@kiltprotocol/sdk-js/build/blockchain/Blockchain'
+import {
+  IS_IN_BLOCK,
+  submitSignedTx,
+} from '@kiltprotocol/sdk-js/build/blockchain/Blockchain'
 
 const DEFAULT_TOKEN_AMOUNT = 500
 
@@ -76,7 +79,7 @@ export class FaucetController {
         new BN(DEFAULT_TOKEN_AMOUNT),
         0
       )
-      const status = await submitSignedTx(tx, {
+      const status = await Blockchain.submitTxWithReSign(tx, faucetAccount, {
         resolveOn: IS_IN_BLOCK,
       })
       return Promise.resolve(status.isInBlock)

--- a/src/faucet/faucet.module.spec.ts
+++ b/src/faucet/faucet.module.spec.ts
@@ -36,13 +36,11 @@ jest.mock('@kiltprotocol/sdk-js/build/balance/Balance.chain', () => {
 jest.mock('@kiltprotocol/sdk-js/build/blockchain/Blockchain', () => {
   return {
     __esModule: true,
-    default: {
-      submitSignedTx: jest.fn(
-        async (): Promise<SubmittableResult> => {
-          return { isInBlock: true } as SubmittableResult
-        }
-      ),
-    },
+    submitSignedTx: jest.fn().mockImplementation(
+      async (): Promise<SubmittableResult> => {
+        return { isInBlock: true } as SubmittableResult
+      }
+    ),
   }
 })
 
@@ -74,7 +72,7 @@ describe('Faucet Module', () => {
       .makeTransfer
 
     const mockedsubmitSignedTx = require('@kiltprotocol/sdk-js/build/blockchain/Blockchain')
-      .default.submitSignedTx
+      .submitSignedTx
 
     const fakeFaucetService: FaucetService = {
       drop: jest.fn(async (): Promise<FaucetDrop> => testFaucetDrop),
@@ -202,9 +200,9 @@ describe('Faucet Module', () => {
         const buildSpy = jest
           .spyOn(Identity, 'buildFromSeed')
           .mockResolvedValue(faucetIdentity)
-          mockedsubmitSignedTx.mockResolvedValue({
-            isInBlock: true,
-          } as SubmittableResult)
+        mockedsubmitSignedTx.mockResolvedValue({
+          isInBlock: true,
+        } as SubmittableResult)
         expect(
           await faucetController['transferTokens'](claimerAddress)
         ).toEqual(true)

--- a/test/faucet.e2e-spec.ts
+++ b/test/faucet.e2e-spec.ts
@@ -16,9 +16,8 @@ jest.mock('@kiltprotocol/sdk-js/build/balance/Balance.chain', () => {
 jest.mock('@kiltprotocol/sdk-js/build/blockchain/Blockchain', () => {
   return {
     __esModules: true,
-    default: {
-      submitSignedTx: jest.fn(() => Promise.resolve({ isInBlock: true })),
-    }
+
+    submitSignedTx: jest.fn(() => Promise.resolve({ isInBlock: true })),
   }
 })
 
@@ -46,11 +45,11 @@ describe('faucet endpoint (e2e)', () => {
 
   beforeEach(async () => {
     await faucetService.reset()
-    require('@kiltprotocol/sdk-js/build/blockchain/Blockchain').default.submitSignedTx.mockResolvedValue(
+    require('@kiltprotocol/sdk-js/build/blockchain/Blockchain').submitSignedTx.mockResolvedValue(
       { isInBlock: true }
     )
     require('@kiltprotocol/sdk-js/build/balance/Balance.chain').makeTransfer.mockResolvedValue(
-      { }
+      {}
     )
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,7 +519,7 @@
     "@polkadot/util" "^3.5.1"
     "@polkadot/util-crypto" "^3.5.1"
 
-"@kiltprotocol/sdk-js@^0.19.1-affad9.0":
+"@kiltprotocol/sdk-js@^0.19.1-affad9d.0":
   version "0.19.1-affad9d.0"
   resolved "https://npm.pkg.github.com/download/@kiltprotocol/sdk-js/0.19.1-affad9d.0/200b384ed5e5bb5d35e21b3da717463e4aa5f9ca5753bb228c1f761dc41e4fab#8d3cfcfedca9f41fd1ff9080cfed29d79af1d2a1"
   integrity sha512-iyY3g1FRNSIleQPLtP9COo/6meu150Z0wTWNMVTFVi9TFRg54V3Tx+/8rc7FI0Qyd0/uAjX8uEBUZ87SDDCIfQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,10 +519,10 @@
     "@polkadot/util" "^3.5.1"
     "@polkadot/util-crypto" "^3.5.1"
 
-"@kiltprotocol/sdk-js@^0.19.1-d0076cb.0":
-  version "0.19.1-d0076cb.0"
-  resolved "https://npm.pkg.github.com/download/@kiltprotocol/sdk-js/0.19.1-d0076cb.0/65c4100d663cb3f26c56a7dadc627e0ed95534e68163016a9943f7e4ed64cedd#18679f21dc1bdbaad7905f569d597a7dd1b5915d"
-  integrity sha512-C8wVrawG67OoLu3hibEdKgF89T0GTMZi70fTcBJebM2oL74wLue0nG8AdIZ6IUuCxuVDqNvDjwNfTTj6LgbIzQ==
+"@kiltprotocol/sdk-js@^0.19.1-affad9.0":
+  version "0.19.1-affad9d.0"
+  resolved "https://npm.pkg.github.com/download/@kiltprotocol/sdk-js/0.19.1-affad9d.0/200b384ed5e5bb5d35e21b3da717463e4aa5f9ca5753bb228c1f761dc41e4fab#8d3cfcfedca9f41fd1ff9080cfed29d79af1d2a1"
+  integrity sha512-iyY3g1FRNSIleQPLtP9COo/6meu150Z0wTWNMVTFVi9TFRg54V3Tx+/8rc7FI0Qyd0/uAjX8uEBUZ87SDDCIfQ==
   dependencies:
     "@kiltprotocol/portablegabi" "^0.4.0"
     "@polkadot/api" "^2.0.1"


### PR DESCRIPTION
## fixes KILTProtocol/ticket#744
When Contact with deprecated format exists in DB we delete on update and respond SDK format.


## How to test:
docker-compose up -d mongodb
start old democlient and old services
register Contact with DID in deprecated format
restart services with this PR included
visit http://localhost:3000/contacts
contact DID should be displayed in updated sdk format

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
