### PR TITLE
fix: faucet identity key type

### DIFF
--- a/src/faucet/faucet.controller.ts
+++ b/src/faucet/faucet.controller.ts
@@ -68,7 +68,10 @@ export class FaucetController {
     try {
       console.log(`Transfer tokens from faucet to ${address}`)
       const faucetAccount: Identity = Identity.buildFromSeed(
-        hexToU8a(process.env.FAUCET_ACCOUNT)
+        hexToU8a(process.env.FAUCET_ACCOUNT),
+        {
+          signingKeyPairType: 'ed25519'
+        }
       )
       const tx = await Balance.makeTransfer(
         faucetAccount,

--- a/src/faucet/faucet.controller.ts
+++ b/src/faucet/faucet.controller.ts
@@ -70,7 +70,7 @@ export class FaucetController {
       const faucetAccount: Identity = Identity.buildFromSeed(
         hexToU8a(process.env.FAUCET_ACCOUNT),
         {
-          signingKeyPairType: 'ed25519'
+          signingKeyPairType: 'ed25519',
         }
       )
       const tx = await Balance.makeTransfer(

--- a/src/faucet/faucet.module.spec.ts
+++ b/src/faucet/faucet.module.spec.ts
@@ -98,7 +98,9 @@ describe('Faucet Module', () => {
     }
     beforeAll(async () => {
       await cryptoWaitReady()
-      faucetIdentity = Identity.buildFromSeed(hexToU8a(FAUCET_SEED))
+      faucetIdentity = Identity.buildFromSeed(hexToU8a(FAUCET_SEED), {
+        signingKeyPairType: 'ed25519',
+      })
       process.env['FAUCET_ACCOUNT'] = FAUCET_SEED
     })
     beforeEach(async () => {
@@ -217,7 +219,10 @@ describe('Faucet Module', () => {
           await faucetController['transferTokens'](claimerAddress)
         ).toEqual(true)
         expect(buildSpy).toHaveBeenCalledWith(
-          hexToU8a(process.env.FAUCET_ACCOUNT)
+          hexToU8a(process.env.FAUCET_ACCOUNT),
+          {
+            signingKeyPairType: 'ed25519',
+          }
         )
         expect(mockedMakeTransfer).toHaveBeenCalledWith(
           faucetIdentity,
@@ -237,7 +242,10 @@ describe('Faucet Module', () => {
           await faucetController['transferTokens'](claimerAddress)
         ).toEqual(false)
         expect(buildSpy).toHaveBeenCalledWith(
-          hexToU8a(process.env.FAUCET_ACCOUNT)
+          hexToU8a(process.env.FAUCET_ACCOUNT),
+          {
+            signingKeyPairType: 'ed25519',
+          }
         )
         expect(mockedMakeTransfer).not.toHaveBeenCalled()
         buildSpy.mockReturnValue(faucetIdentity)
@@ -248,7 +256,10 @@ describe('Faucet Module', () => {
           await faucetController['transferTokens'](claimerAddress)
         ).toEqual(false)
         expect(buildSpy).toHaveBeenCalledWith(
-          hexToU8a(process.env.FAUCET_ACCOUNT)
+          hexToU8a(process.env.FAUCET_ACCOUNT),
+          {
+            signingKeyPairType: 'ed25519',
+          }
         )
         expect(mockedMakeTransfer).toHaveBeenCalledWith(
           faucetIdentity,
@@ -263,7 +274,10 @@ describe('Faucet Module', () => {
           await faucetController['transferTokens'](claimerAddress)
         ).toEqual(false)
         expect(buildSpy).toHaveBeenCalledWith(
-          hexToU8a(process.env.FAUCET_ACCOUNT)
+          hexToU8a(process.env.FAUCET_ACCOUNT),
+          {
+            signingKeyPairType: 'ed25519',
+          }
         )
         expect(mockedMakeTransfer).toHaveBeenCalledWith(
           faucetIdentity,


### PR DESCRIPTION
## relates to https://github.com/KILTprotocol/ticket/issues/763
This PR fixes the faucet not giving out tokens, because it needs ed25510 as key algo.

## How to test:
- Get tokens via `curl -X POST http://localhost:3000/faucet/drop --data '{"address": "<address>"}' -H "Content-Type: application/json"`

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
